### PR TITLE
Update index.md

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -117,7 +117,7 @@ If you want to test code wich use **Storage**, the testfile needs to initialize 
 Use this in your *_test.go file:
 ```
 func TestMain(m *testing.M) {
-        dir := ""
+        dir := "/tmp"
         storage.SetDataDir(dir)
         os.Exit(m.Run())
  }

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -113,3 +113,13 @@ func (s *sshStorage) PrivateKey() *privateKey {
         }
 }
 ```
+If you want to test code wich use **Storage**, the testfile needs to initialize the storage first.
+Use this in your *_test.go file:
+```
+func TestMain(m *testing.M) {
+        dir := ""
+        storage.SetDataDir(dir)
+        os.Exit(m.Run())
+ }
+ ```
+ 


### PR DESCRIPTION
Storage is not initialized if you run tests, they panic with a nil dereference because db is not set.
I also made a change in storage code which allows this only once. (see pull request)

This is a temporary workaround to address a known issue with GitHub.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
